### PR TITLE
(cmd, conn, logger): include conn pkg

### DIFF
--- a/cmd/helloworld/main.go
+++ b/cmd/helloworld/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+
+	"github.com/edualb/ghype/internal/conn"
+)
+
+func main() {
+	// When we type curl localhost:8080,
+	// We are receveing the following error: curl: (1) Received HTTP/0.9 when not allowed
+	s := conn.NewServer("tcp", ":8080")
+	log.Fatal(s.Listen())
+}

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -1,0 +1,68 @@
+package conn
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/edualb/ghype/internal/logger"
+)
+
+const (
+	protocolHTTP = "tcp"
+	addressHTTP  = ":80"
+)
+
+type Server struct {
+	Protocol string
+	Address  string
+
+	logger *logger.Logger
+}
+
+func NewServer(protocol, address string) Server {
+	return Server{
+		Protocol: protocol,
+		Address:  address,
+
+		logger: logger.New(),
+	}
+}
+
+func (s Server) Listen() error {
+	protocol := protocolHTTP
+	address := addressHTTP
+
+	if s.Address != "" {
+		address = s.Address
+	}
+
+	if s.Protocol != "" {
+		protocol = s.Protocol
+	}
+
+	listener, err := net.Listen(protocol, address)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Infof(fmt.Sprintf("Listening on %s\n", address))
+	for {
+		s.logger.Infof("Waiting for connection...\n")
+		conn, err := listener.Accept()
+		if err != nil {
+			s.logger.Errof(fmt.Sprintf("connection error: %s\n", err.Error()))
+			continue
+		}
+		s.logger.Infof("Connection accepeted\n")
+
+		conn.Write([]byte("Hello world!\n"))
+
+		s.logger.Infof("closing connection\n")
+		err = conn.Close()
+		if err != nil {
+			s.logger.Errof(fmt.Sprintf("closing connection error: %s\n", err.Error()))
+			continue
+		}
+		s.logger.Infof("Connection is done\n")
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,45 @@
+package logger
+
+import (
+	"log"
+	"os"
+	"sync"
+)
+
+type Logger struct {
+	stderr *os.File
+	stdout *os.File
+
+	mu *sync.Mutex
+}
+
+func New() *Logger {
+	return &Logger{
+		stderr: os.Stderr,
+		stdout: os.Stdout,
+
+		mu: &sync.Mutex{},
+	}
+}
+
+func (l *Logger) Errof(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stderr == nil {
+		l.stderr = os.Stderr
+	}
+	logger := log.New(l.stderr, "", log.LstdFlags)
+	w := logger.Writer()
+	w.Write([]byte(msg))
+}
+
+func (l *Logger) Infof(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stdout == nil {
+		l.stdout = os.Stdout
+	}
+	logger := log.New(l.stdout, "", log.LstdFlags)
+	w := logger.Writer()
+	w.Write([]byte(msg))
+}


### PR DESCRIPTION
Issues:
- #6 
- #5 

Informations:
- We developed the logger pkg which has just two functions: Errof and
Infof that writes in stderr and stdout

- conn is receveing a connection and writes "Hello World" to the
client. If we send a curl, we are receveing the following error: curl: (1) Received HTTP/0.9 when not allowed